### PR TITLE
Offers and initial README and `Brewfile`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,8 @@
+# use the Replicated tap for installing the Replicated CLI
+tap "replicatedhq/replicated"
+brew "replicatedhq/replicated/cli"
+# use the Spin tap to install the Spin framework
+tap "fermyon/tap"
+brew "fermyon/tap/spin"
+# install Helm from the main brew repository
+brew "helm"


### PR DESCRIPTION
TL;DR
-----

Helps others use this repository with some docs and ergnomics

Details
-------

Starts to document the demonstration with a short README that will help
someone familiar with Replicated and the available tooling use it.
There's enough information for an experienced person to use what they
know to build and release the application, but not enough to get brand
new to Replicated going.

Also simplifies getting started by providing a `Brewfile` to assure the
required CLIs are installed.

To Do
-----

Expand the README to be usable by someone who's less familiar with the
Replicated platform.
