### PR TITLE
Adds delimiter and header to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ use [Homebrew](https://brew.sh), you can install all of them with `brew bundle i
 
 ### Makefile Reference
     
+| target    | purpose |
+|-----------|---------|
 | `app`     | Creates an application for the demo on the Replicated Vendor Portal |
 | `lint`    | Run the linter against the release |
 | `build`   | Builds the WASM module from the Go source code using TinyGo |


### PR DESCRIPTION
TL;DR
-----

Fixes Makefile target table by adding a delimiter row

Details
-------

Corrects a mistake I made in not understanding that the header and
delimiter rows are  requried for GH-flavored Markdown tables.
